### PR TITLE
Remove unneeded mkdirp and pad dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ notifications:
 node_js:
   - node
   - lts/*
+  - 10
   - 8
 after_success:
   - test `node --version | cut -c 2,3` -eq 10 && npm run coveralls

--- a/lib/util/printers.js
+++ b/lib/util/printers.js
@@ -1,18 +1,16 @@
 'use strict'
 
 const clc = require('./cli-color-optional')
-const padLeft = require('pad-left')
-const padRight = require('pad-right')
 
 function padNumber (number) {
-  return padLeft(number.toString(), 5, ' ')
+  return number.toString().padStart(5, ' ')
 }
 
 function formatBrowserName (browser) {
   const name = browser.name
     .replace(/^(\w+).*$/, '$1')
     .replace('Headless', '')
-  return padRight(name, 7, ' ')
+  return name.padEnd(7, ' ')
 }
 
 function printStats (browser, meaning, total, success, failed, skipped) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2244,12 +2244,14 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -2673,22 +2675,6 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
-    "pad-left": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-2.1.0.tgz",
-      "integrity": "sha1-FuajstRKjhOMsIOMx8tAOk/J6ZQ=",
-      "requires": {
-        "repeat-string": "^1.5.4"
-      }
-    },
-    "pad-right": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
-      "integrity": "sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=",
-      "requires": {
-        "repeat-string": "^1.5.2"
-      }
-    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3030,11 +3016,6 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
       "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
       "dev": true
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "request": {
       "version": "2.88.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     }
   ],
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "main": "index.js",
   "scripts": {
@@ -35,10 +35,7 @@
     "semantic-release": "semantic-release"
   },
   "dependencies": {
-    "cli-color": "1.4.0",
-    "mkdirp": "0.5.1",
-    "pad-left": "2.1.0",
-    "pad-right": "0.2.2"
+    "cli-color": "1.4.0"
   },
   "devDependencies": {
     "chai": "4.2.0",

--- a/test/printers.test.js
+++ b/test/printers.test.js
@@ -4,7 +4,6 @@
 const rewire = require('rewire')
 const chai = require('chai')
 const sinon = require('sinon')
-const pad = require('pad-left')
 
 chai.config.includeStack = true
 chai.use(require('sinon-chai'))
@@ -171,10 +170,10 @@ describe('printers.js test suite', function () {
       }
 
       clcFake.move.right.returns(tab)
-      clcFake.yellow.withArgs(pad(stats.total.toString(), 5, ' ') + ' total  ').returns('yellow>' + stats.total)
-      clcFake.green.withArgs(pad(stats.success.toString(), 5, ' ') + ' passed').returns('green>' + stats.success)
-      clcFake.red.withArgs(pad(stats.failed.toString(), 5, ' ') + ' failed').returns('red>' + stats.failed)
-      clcFake.cyan.withArgs(pad(stats.skipped.toString(), 5, ' ') + ' skipped').returns('cyan>' + stats.skipped)
+      clcFake.yellow.withArgs(stats.total.toString().padStart(5, ' ') + ' total  ').returns('yellow>' + stats.total)
+      clcFake.green.withArgs(stats.success.toString().padStart(5, ' ') + ' passed').returns('green>' + stats.success)
+      clcFake.red.withArgs(stats.failed.toString().padStart(5, ' ') + ' failed').returns('red>' + stats.failed)
+      clcFake.cyan.withArgs(stats.skipped.toString().padStart(5, ' ') + ' skipped').returns('cyan>' + stats.skipped)
 
       printers.__set__('write', writeFake)
 


### PR DESCRIPTION
* The 'mkdirp' package does not appear to be used.
  If something like it is needed, `fs.mkdirSync(…,{recursive:true})`
  was introduced in Node 10, which is the oldest LTS release
  that is currently supported (non-EOL).

* The padStart and padEnd methods were spec'ed in ES6 and
  implemented since Node 8.
  <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart>
  <https://node.green/>

-------

Also:
* Added `10` explicitly to the Travis matrix since latest=14 and lts=12 now, which means coverage was no longer triggered.
* Update package.json to reflect that Node 6 has not been supported since 4479f19a8eb6.